### PR TITLE
Arrange components and books lists in the main page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,48 @@
-import "./App.css";
+/* eslint-disable no-unused-vars */
+import classes from "./App.module.css";
+
+import Filters from "./components/Filters/Filters";
+import BooksList from "./components/BooksList/BooksList";
+import BooksCounter from "./components/BooksCounter/BooksCounter";
+import { library } from "../books.json";
 
 function App() {
-  return <h1>Hello World</h1>;
+  const onClickAddButtonHandler = (ISBN) => {
+    console.log("Add");
+  };
+
+  const onClickRemoveButtonHandler = (ISBN) => {
+    console.log("Remove");
+  };
+
+  return (
+    <main className={classes["main-wrapper"]}>
+      <section className={classes["available-books"]}>
+        <section className={classes["header-wrapper"]}>
+          <BooksCounter
+            availableBooks={library.length}
+            selectedBooks={library.length}
+          />
+          <Filters />
+        </section>
+        <BooksList
+          data={library}
+          isAddButtonEnabled={true}
+          onClickAddButton={onClickAddButtonHandler}
+        />
+      </section>
+      {library.length > 0 && (
+        <aside className={classes["selected-books"]}>
+          <h2 className={classes.title}>Reading list</h2>
+          <BooksList
+            data={library}
+            isRemoveButtonEnabled={true}
+            onClickRemoveButton={onClickRemoveButtonHandler}
+          />
+        </aside>
+      )}
+    </main>
+  );
 }
 
 export default App;

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,50 @@
+.main-wrapper {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  column-gap: 1.5rem;
+  padding: 2rem 4rem;
+  grid-template-areas: "available selected";
+}
+
+.available-books {
+  grid-area: available;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.selected-books {
+  grid-area: selected;
+  border: 1px solid #ffffff;
+  padding: 24px 4px;
+  border-radius: 12px;
+  background-color: #1a1a1a;
+}
+
+.selected-books .title {
+  text-align: center;
+}
+
+.header-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: center;
+}
+
+@media (max-width: 80rem) {
+  .main-wrapper {
+    grid-template: 1fr 1fr / 1fr;
+    gap: 80px 0;
+    justify-content: space-between;
+    grid-template-areas:
+      "available"
+      "selected";
+    padding: 2rem 1rem;
+  }
+
+  .selected-books {
+    align-items: center;
+  }
+}


### PR DESCRIPTION
The main page displays components and elements in their right place

Main Page look and feel:

- Desktop view:

![image](https://github.com/MrLapa/reading-list-technical-test/assets/5798165/d81959f2-d2ad-4fba-b6c0-9568f63aac23)

- Mobile view

![image](https://github.com/MrLapa/reading-list-technical-test/assets/5798165/538c6d3a-a020-4d02-aafb-14687d9ca187)

![image](https://github.com/MrLapa/reading-list-technical-test/assets/5798165/43e5b44a-0fa5-4997-b94a-ecf3af85b772)

